### PR TITLE
Added additional error handling and minor optimizations

### DIFF
--- a/booktree.py
+++ b/booktree.py
@@ -278,8 +278,13 @@ def buildTreeFromHybridSources(path, mediaPath, files, logfile, cfg):
                             book[b].metadata = "audible" 
 
             # Scrape available metadata from Goodreads
-            bk = book[b].bestMAMMatch
-            book[b].bestMAMMatch = goodreads_book.fetch_all(bk,title=bk.getCleanTitle(),author=bk.getAuthors())
+            try:
+                bk = book[b].bestMAMMatch
+                print(f"Clean title: {bk.getCleanTitle()}")
+                book[b].bestMAMMatch = goodreads_book.fetch_all(bk,title=bk.getCleanTitle(),author=bk.getAuthors())
+            except Exception as e:
+                print("Couldn't get Goodreads data")
+                book[b].bestMAMMatch = bk
 
             print (f"Found {len(book[b].mamMatches)} MAM matches, {len(book[b].audibleMatches)} Audible Matches")
             myx_utilities.printDivider()

--- a/goodreads.py
+++ b/goodreads.py
@@ -24,42 +24,45 @@ class Goodreads:
         self.driver=self.start_webdriver(True)
 
     def fetch_all(self, book, isbn="", title="", author=""):
-        # get the url for the book page on goodreads
-        url = self.search_goodreads(isbn, title, author)
+        try:
+            # get the url for the book page on goodreads
+            url = self.search_goodreads(isbn, title, author)
 
-        # get the HTML for the book page
-        page = self.get_book_page_content(url, self.driver)
+            # get the HTML for the book page
+            page = self.get_book_page_content(url, self.driver)
 
-        # parse for the original publication year
-        book.publication_year = self.get_original_publication_year(page)
+            # parse for the original publication year
+            book.publication_year = self.get_original_publication_year(page)
 
-        # parse for the description
-        book.description = self.get_description(page)
+            # parse for the description
+            book.description = self.get_description(page)
 
-        # parse for the genres. the get_genres method returns a list, so we convert the list into a CSV string
-        categories = ','.join(self.get_genres(page))
+            # parse for the genres. the get_genres method returns a list, so we convert the list into a CSV string
+            categories = ','.join(self.get_genres(page))
 
-        # use the categories data to set the genres
-        book.setGenres(categories)
+            # use the categories data to set the genres
+            book.setGenres(categories)
 
-        # use the categories data to set the tags
-        book.setTags(categories)
+            # use the categories data to set the tags
+            book.setTags(categories)
 
-        # parse for the series
-        series = self.get_series(page)
-        
-        book.series.clear()
-        if series:
-            for name, part in series.items():
-                book.series.append(myx_classes.Series(name, part))
+            # parse for the series
+            series = self.get_series(page)
+            
+            book.series.clear()
+            if series:
+                for name, part in series.items():
+                    book.series.append(myx_classes.Series(name, part))
 
-        # parse for the publisher
-        book.publisher = self.get_publisher(page)
+            # parse for the publisher
+            book.publisher = self.get_publisher(page)
 
-        # parse for the ISBN
-        book.isbn = self.get_isbn(page)
+            # parse for the ISBN
+            book.isbn = self.get_isbn(page)
 
-        return book
+            return book
+        except Exception as e:
+            print("Encountered an issue fetching Goodreads metadata")
 
     def start_webdriver(self, headless):
         try:    


### PR DESCRIPTION
The scraper should only check for the signup modal once now, which should shave down the runtime. The scraper will also stop processing a book if the search doesn't return a result.